### PR TITLE
Run `nanshe` tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,11 +9,11 @@ RUN conda config --add channels jakirkham && \
     conda remove -y -n _test --all && \
     conda clean -tipsy
 
-RUN git clone https://github.com/jakirkham/nanshe /nanshe && \
-    cd /nanshe && \
-    NANSHE_VERSION=`conda list -f nanshe 2>/dev/null | \
+RUN NANSHE_VERSION=`conda list -f nanshe 2>/dev/null | \
                     tail -1 | \
                     python -c "from sys import stdin; print(stdin.read().split()[1])"` && \
+    git clone https://github.com/jakirkham/nanshe /nanshe && \
+    cd /nanshe && \
     git checkout "v${NANSHE_VERSION}" && \
     conda remove -y nanshe && \
     /usr/share/docker/entrypoint.sh nosetests && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,9 @@ RUN conda config --add channels jakirkham && \
     rm -rf /opt/conda/conda-bld/work/* && \
     conda remove -y -n _build --all && \
     conda remove -y -n _test --all && \
-    conda clean -tipsy
+    cp /opt/conda/pkgs/nanshe-*.tar.bz2 / && \
+    conda clean -tipsy && \
+    mv /nanshe-*.tar.bz2 /opt/conda/pkgs/
 
 RUN NANSHE_VERSION=`conda list -f nanshe 2>/dev/null | \
                     tail -1 | \

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN git clone https://github.com/jakirkham/nanshe /nanshe && \
                    tail -1 | \
                    python -c "from sys import stdin; print(stdin.read().split()[1])"` && \
     conda remove -y nanshe && \
-    nosetests && \
+    /usr/share/docker/entrypoint.sh nosetests && \
     conda install -y nanshe && \
     cd / && \
     rm -rf /nanshe

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,9 @@ RUN conda config --add channels jakirkham && \
 RUN NANSHE_VERSION=`conda list -f nanshe 2>/dev/null | \
                     tail -1 | \
                     python -c "from sys import stdin; print(stdin.read().split()[1])"` && \
-    git clone https://github.com/jakirkham/nanshe /nanshe && \
+    curl -L "https://github.com/jakirkham/nanshe/archive/v${NANSHE_VERSION}.tar.gz" | tar -xzf - && \
+    mv "/nanshe-${NANSHE_VERSION}" /nanshe && \
     cd /nanshe && \
-    git checkout "v${NANSHE_VERSION}" && \
     conda remove -y nanshe && \
     /usr/share/docker/entrypoint.sh nosetests && \
     conda install -y `find /opt/conda/pkgs -name "nanshe-${NANSHE_VERSION}-*py27*.tar.bz2"` && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,3 +8,14 @@ RUN conda config --add channels jakirkham && \
     conda remove -y -n _build --all && \
     conda remove -y -n _test --all && \
     conda clean -tipsy
+
+RUN git clone https://github.com/jakirkham/nanshe /nanshe && \
+    cd /nanshe && \
+    git checkout v`conda list -f nanshe 2>/dev/null | \
+                   tail -1 | \
+                   python -c "from sys import stdin; print(stdin.read().split()[1])"` && \
+    conda remove -y nanshe && \
+    nosetests && \
+    conda install -y nanshe && \
+    cd / && \
+    rm -rf /nanshe

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN NANSHE_VERSION=`conda list -f nanshe 2>/dev/null | \
     git checkout "v${NANSHE_VERSION}" && \
     conda remove -y nanshe && \
     /usr/share/docker/entrypoint.sh nosetests && \
-    conda install -y nanshe && \
+    conda install -y `find /opt/conda/pkgs -name "nanshe-${NANSHE_VERSION}-*py27*.tar.bz2"` && \
     conda clean -tipsy && \
     cd / && \
     rm -rf /nanshe

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,5 +20,6 @@ RUN NANSHE_VERSION=`conda list -f nanshe 2>/dev/null | \
     conda remove -y nanshe && \
     /usr/share/docker/entrypoint.sh nosetests && \
     conda install -y nanshe && \
+    conda clean -tipsy && \
     cd / && \
     rm -rf /nanshe

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,10 @@ RUN conda config --add channels jakirkham && \
 
 RUN git clone https://github.com/jakirkham/nanshe /nanshe && \
     cd /nanshe && \
-    git checkout v`conda list -f nanshe 2>/dev/null | \
-                   tail -1 | \
-                   python -c "from sys import stdin; print(stdin.read().split()[1])"` && \
+    NANSHE_VERSION=`conda list -f nanshe 2>/dev/null | \
+                    tail -1 | \
+                    python -c "from sys import stdin; print(stdin.read().split()[1])"` && \
+    git checkout "v${NANSHE_VERSION}" && \
     conda remove -y nanshe && \
     /usr/share/docker/entrypoint.sh nosetests && \
     conda install -y nanshe && \

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ If one wishes to develop this repo, building will need to be performed manually.
 
 # Testing
 
-Only releases of `nanshe` are installed in this repo. As `nanshe` is only released if it passes a build and is actively tested in this exact same environment, no further testing is performed. The container used by this container as a base, `jakirkham/centos_drmaa_conda`, is tested independently. As a result, this container does not have any test of its own.
+Only releases of `nanshe` are installed in this repo. `nanshe` is only released if it passes a build and is actively tested in this exact same environment. That being said, the test suite is run for the installed release of `nanshe` during the build phase. If it fails, the build phase will be interrupted and the container will not be released. The container used by this container as a base, `jakirkham/centos_drmaa_conda`, is tested independently. As a result, this container does not have any test of its own.
 
 # Usage
 


### PR DESCRIPTION
This makes sure tests are run during the build phase.  If the tests fail, this blocks a container release on Docker Hub or tagging the image if building locally. If they pass, the container behaves the same. However, it adds another layer. The main concern here is to make sure conda package updates don't break the container.